### PR TITLE
Update Link for Awesome Alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ This section is for inactive projects that are nonetheless still of interest reg
 - [Awesome Diversity](https://github.com/folkswhocode/awesome-diversity) - A curated list of amazing articles, websites and resources about diversity in technology.
 - [Awesome Free Software](https://github.com/johnjago/awesome-free-software) - A curated list of free as in freedom software.
 - [Awesome Ad-Free](https://github.com/johnjago/awesome-ad-free) - A curated list of ad-free alternatives to popular services on the web.
-- [Awesome Alternatives](https://codeberg.org/LinuxCafeFederation/awesome-alternatives) - A curated list of (F)OSS / Federated alternatives to proprietary software and services.
+- [Awesome Alternatives](https://gitlab.com/linuxcafefederation/awesome-alternatives) - A curated list of (F)OSS / Federated alternatives to proprietary software and services.
 
 Also check out these sites for great alternatives to the monopolistic, privacy-invading software you may now be using:
 


### PR DESCRIPTION
We decided to host it in GitLab, since it can automatically push to other Git sites. Codeberg and GitHub repos are now mirrors

In case you want to double check if I am legit, I am part of the organization: https://github.com/orgs/LinuxCafeFederation/people

/cc @CipherOps