### PR TITLE
Add Fedishare

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ The [Fediverse](https://en.wikipedia.org/wiki/Fediverse) is the place of hope fo
 - [Watomatic](https://github.com/adeekshith/watomatic) - Auto reply for WhatsApp so you can stop using it.
 - [Scribe](https://scribe.rip/) [<img src="https://raw.githubusercontent.com/humanetech-community/awesome-humane-tech/main/logo/sourcehut.svg?sanitize=true" width="16"/>](https://git.sr.ht/~edwardloveall/scribe) - Privacy-respecting and minimal alternative front end for Medium.com.
 - [Piped](https://piped.kavin.rocks) [<img src="https://raw.githubusercontent.com/humanetech-community/awesome-humane-tech/main/logo/github.svg?sanitize=true" width="16"/>](https://github.com/TeamPiped/Piped) - An alternative privacy-friendly YouTube frontend which is efficient by design.
+- [Fedishare](https://addons.mozilla.org/en-US/firefox/addon/fedishare-addon/) [<img src="https://raw.githubusercontent.com/humanetech-community/awesome-humane-tech/main/logo/gitlab.svg?sanitize=true" width="16"/>](https://gitlab.com/mugcake/fedishare) - Firefox addon to share the current tab on the fediverse.
 
 ## Translation
 


### PR DESCRIPTION
A firefox addon that allows you to share web pages (current tab) from the toolbar button to your fediverse instance(s); diaspora, pleroma, mastodon, etc.

- [x] I have referred the list and did not find this submission already added.
- [x] I have read the contribution guidelines [here](https://github.com/humanetech-community/awesome-humane-tech/blob/main/contributing.md).
- [x] I have read the code of conduct and I agree to adhere to the same [here](https://github.com/humanetech-community/awesome-humane-tech/blob/main/code-of-conduct.md)
- [x] I have added my entry as the latest (last dotted point) under a topic, not at the beginning, not interleaved.

If your suggested entry is code project:

- [x] I have checked that the project is open source and has a [FSF-approved](https://www.gnu.org/licenses/license-list.html) license.

### Name of my software/tool/service/technology/project :
Fedishare

### Explain why it's a Humane Technology: {}
It's an excelent alternative to the sharing buttons/plugins that are embedded in websites, which in most cases only share to centralized/proprietary services.

### Sourcecode is available at :
[Gitlab repo](https://gitlab.com/mugcake/fedishare)

### Is there a similar software/tool etc., that already exists?
It was originally a fork of [another addon](https://github.com/shivarajnaidu/URL-sharer) that only shares to centralized/proprietary social networks; adapting it to share only to FOSS projects. 

It was rewritten from scratch and now has unique features:
- enable/disable buttons (instances).
- default instances or set your own.
- many services/protocols supported.

### Add any other topic/section here you wish to explain and elaborate
[This article (in Spanish)](https://victorhckinthefreeworld.com/2018/04/06/como-anadir-un-boton-en-tu-wordpress-para-compartir-contenido-en-mastodon-diaspora-gnusocial-o-hubzilla/) inspired me to create the addon.