### PR TITLE
Update link to ungoogled-chromium repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Security is an important aspect of humane technology. It is also a vast field we
 
 - [Privacy Guides](https://privacyguides.org) [<img src="https://raw.githubusercontent.com/humanetech-community/awesome-humane-tech/main/logo/github.svg?sanitize=true" width="16"/>](https://github.com/privacyguides/privacyguides.org) - Knowledge and tools to protect your privacy against global mass surveillance.
 - [Privacy Respecting](https://github.com/nikitavoloboev/privacy-respecting) - A curated list of privacy-respecting Services and Software.
-- [Ungoogled Chromium](https://github.com/Eloston/ungoogled-chromium) - Chromium without Google integration, enhancing privacy, control, transparency
+- [Ungoogled Chromium](https://github.com/ungoogled-software/ungoogled-chromium) - Chromium without Google integration, enhancing privacy, control, transparency
 - [Signal](https://www.signal.org/) [<img src="https://raw.githubusercontent.com/humanetech-community/awesome-humane-tech/main/logo/github.svg?sanitize=true" width="16"/>](https://github.com/signalapp) - Signal is a messaging app for simple private communication with friends.
 - [Local Sheriff](https://github.com/cliqz-oss/local-sheriff) - Browser extension to help identify what sensitive information (PII) is shared / leaked to 3rd-parties.
 - [Webbkoll](https://webbkoll.dataskydd.net) [<img src="https://raw.githubusercontent.com/humanetech-community/awesome-humane-tech/main/logo/github.svg?sanitize=true" width="16"/>](https://github.com/andersju/webbkoll) - An online tool that checks how a website is doing with regards to privacy.


### PR DESCRIPTION
The main ungoogled-chromium repository has migrated to the ungoogled-software github organisation.

(not sure if I was supposed to fill out anything, the pull request template didn't really match an url change)